### PR TITLE
Bug: Authorization header getting duplicated in some requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml
+/.idea/jarRepositories.xml
 .DS_Store
 /build
 /captures

--- a/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
+++ b/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
@@ -13,7 +13,7 @@ internal const val SIGNING_ALGORITHM = "AWS4-HMAC-SHA256"
  */
 internal fun Request.signed(accessKeyId: String, accessKey: String, region: String, service: String) =
     newBuilder()
-        .addHeader("Authorization", awsAuthorizationHeader(accessKeyId, accessKey, region, service))
+        .header("Authorization", awsAuthorizationHeader(accessKeyId, accessKey, region, service))
         .build()
 
 internal fun Request.awsAuthorizationHeader(accesKeyId: String, accessKey: String, region: String, service: String) =

--- a/okhttp-aws-signer/src/test/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/SigningTest.kt
+++ b/okhttp-aws-signer/src/test/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/SigningTest.kt
@@ -33,6 +33,27 @@ class SigningTest {
     }
 
     @Test
+    fun `signing request should only allow one Authorization header`() {
+        val request = request {
+            url = "http://example.amazonaws.com"
+
+            headers = mapOf(
+                "My-Header1" to "value4,value1,value3,value2",
+                "X-Amz-Date" to "20150830T123600Z"
+            )
+
+            get()
+        }
+
+        val signer = OkHttpAwsV4Signer("us-east-1", "service")
+        val result = signer.sign(request, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+        val secondResult = signer.sign(result, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+
+        assertThat(secondResult.headers().toString().lines().filter { it.startsWith("Authorization") }.size)
+            .isEqualTo(1)
+    }
+
+    @Test
     fun `signing request with headers that should not have multiple spaces`() {
         val request = request {
             url = "http://example.amazonaws.com"
@@ -206,7 +227,9 @@ class SigningTest {
             .sign(request, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
 
         assertThat(result.headers()["Authorization"])
-            .isEqualTo(ResourceHelper.readResource("get-vanilla-empty-query-key.sreq").lineStartingWith("Authorization"))
+            .isEqualTo(
+                ResourceHelper.readResource("get-vanilla-empty-query-key.sreq").lineStartingWith("Authorization")
+            )
     }
 
     @Test
@@ -225,7 +248,9 @@ class SigningTest {
             .sign(request, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
 
         assertThat(result.headers()["Authorization"])
-            .isEqualTo(ResourceHelper.readResource("get-vanilla-query-order-key-case.sreq").lineStartingWith("Authorization"))
+            .isEqualTo(
+                ResourceHelper.readResource("get-vanilla-query-order-key-case.sreq").lineStartingWith("Authorization")
+            )
     }
 
     @Test
@@ -243,7 +268,9 @@ class SigningTest {
             .sign(request, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
 
         assertThat(result.headers()["Authorization"])
-            .isEqualTo(ResourceHelper.readResource("get-vanilla-query-order-key.sreq").lineStartingWith("Authorization"))
+            .isEqualTo(
+                ResourceHelper.readResource("get-vanilla-query-order-key.sreq").lineStartingWith("Authorization")
+            )
     }
 
     @Test
@@ -318,7 +345,9 @@ class SigningTest {
             .sign(request, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
 
         assertThat(result.headers()["Authorization"])
-            .isEqualTo(ResourceHelper.readResource("post-vanilla-empty-query-value.sreq").lineStartingWith("Authorization"))
+            .isEqualTo(
+                ResourceHelper.readResource("post-vanilla-empty-query-value.sreq").lineStartingWith("Authorization")
+            )
     }
 
     @Test

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -1,3 +1,4 @@
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '6.8.2'
+    distributionUrl = distributionUrl.replace("bin", "all")
 }


### PR DESCRIPTION
So long story short...
We are seeing the Android app every so often (we believe when the first request fails due to session expiry perhaps) that a request passes through the interceptor in the android codebase and comes through to the AWS signing methods within this codebase...

We have noticed that often these second FAILING requests have the `Authorization` header twice with 2 differing values on them.
Whether or not this is an actual problem for the app or not this behaviour does not seem correct and instead of using the `addHeader` function on the builder, we should instead use the `header` function to set the header and override it if it already exists, as currently if this sign function is called again with an existing request the header will be added again.

Thats our current school of thought, maybe this fixed the problem we are having on the android codebase side, maybe not, but either way, unless the desired behaviour WAS to have multiple `Authorization` headers in some requests then this change should be preferable either way!

Please let me know what you think before merging this request as obviously this will effect EVERY network request in the app and I don't want to "fix" something if its not broken! @s-ka @soulim 