### PR TITLE
Hash body as byte stream instead of string

### DIFF
--- a/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/Hashing.kt
+++ b/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/Hashing.kt
@@ -1,5 +1,6 @@
 package com.babbel.mobile.android.commons.okhttpawssigner.internal
 
+import java.io.InputStream
 import java.nio.charset.Charset
 import java.security.MessageDigest
 import javax.crypto.Mac
@@ -12,6 +13,12 @@ internal fun hash(value: String): String {
     val bytes = value.toByteArray()
     val md = MessageDigest.getInstance(HASHING_ALGORITHM)
     val digest = md.digest(bytes)
+    return digest.toHexString()
+}
+
+internal fun hash(inputStream: InputStream): String {
+    val md = MessageDigest.getInstance(HASHING_ALGORITHM)
+    val digest = md.digest(inputStream.readAllBytes())
     return digest.toHexString()
 }
 

--- a/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/Hashing.kt
+++ b/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/Hashing.kt
@@ -1,5 +1,6 @@
 package com.babbel.mobile.android.commons.okhttpawssigner.internal
 
+import okio.Buffer
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.security.MessageDigest
@@ -16,9 +17,9 @@ internal fun hash(value: String): String {
     return digest.toHexString()
 }
 
-internal fun hash(inputStream: InputStream): String {
+internal fun hash(bytes: ByteArray): String {
     val md = MessageDigest.getInstance(HASHING_ALGORITHM)
-    val digest = md.digest(inputStream.readAllBytes())
+    val digest = md.digest(bytes)
     return digest.toHexString()
 }
 

--- a/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
+++ b/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
@@ -3,6 +3,7 @@ package com.babbel.mobile.android.commons.okhttpawssigner.internal
 import okhttp3.Headers
 import okhttp3.Request
 import okio.Buffer
+import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.util.Locale
 
@@ -93,7 +94,7 @@ private fun Request.signedHeaders() =
         .joinToString(";")
 
 private fun Request.bodyDigest() =
-    hash(bodyAsString()).lowercase(Locale.ENGLISH)
+    hash(bodyAsInputStream()).lowercase(Locale.ENGLISH)
 
 /**
  * Get the amazon header with date.
@@ -124,6 +125,16 @@ private fun Request.bodyAsString() =
         buffer.readUtf8()
     } ?: ""
 
+/**
+ * Read the request body without changing the current one.
+ * Returns empty string on empty body.
+ */
+private fun Request.bodyAsInputStream() =
+    body?.let {
+        val buffer = Buffer()
+        this.newBuilder().build().body!!.writeTo(buffer)
+        buffer.inputStream()
+    } ?: ByteArrayInputStream("".toByteArray())
 private fun Headers.canonicalHeaders() =
     names().joinToString("\n") {
         "${it.lowercase(Locale.ENGLISH)}:${values(it).trimmedAndJoined()}"

--- a/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
+++ b/okhttp-aws-signer/src/main/kotlin/com/babbel/mobile/android/commons/okhttpawssigner/internal/RequestExtensions.kt
@@ -3,7 +3,6 @@ package com.babbel.mobile.android.commons.okhttpawssigner.internal
 import okhttp3.Headers
 import okhttp3.Request
 import okio.Buffer
-import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.util.Locale
 
@@ -94,7 +93,7 @@ private fun Request.signedHeaders() =
         .joinToString(";")
 
 private fun Request.bodyDigest() =
-    hash(bodyAsInputStream()).lowercase(Locale.ENGLISH)
+    hash(bodyAsByteArray()).lowercase(Locale.ENGLISH)
 
 /**
  * Get the amazon header with date.
@@ -116,25 +115,14 @@ private fun Request.amazonDateHeaderShort() =
 
 /**
  * Read the request body without changing the current one.
- * Returns empty string on empty body.
  */
-private fun Request.bodyAsString() =
+private fun Request.bodyAsByteArray() =
     body?.let {
         val buffer = Buffer()
         this.newBuilder().build().body!!.writeTo(buffer)
-        buffer.readUtf8()
-    } ?: ""
+        buffer.readByteArray()
+    } ?: byteArrayOf()
 
-/**
- * Read the request body without changing the current one.
- * Returns empty string on empty body.
- */
-private fun Request.bodyAsInputStream() =
-    body?.let {
-        val buffer = Buffer()
-        this.newBuilder().build().body!!.writeTo(buffer)
-        buffer.inputStream()
-    } ?: ByteArrayInputStream("".toByteArray())
 private fun Headers.canonicalHeaders() =
     names().joinToString("\n") {
         "${it.lowercase(Locale.ENGLISH)}:${values(it).trimmedAndJoined()}"


### PR DESCRIPTION
Hashing as string causes issue when the request body is binary. This should fix #5 .